### PR TITLE
fix: ws labels from settings event

### DIFF
--- a/controller/controller.py
+++ b/controller/controller.py
@@ -170,6 +170,10 @@ class Controller:
             self._session = await self._stack.enter_async_context(
                 ClientSession(base_url=self.base_url, headers=self.headers)
             )
+
+        # Get settings
+        settings = await self.record("settings")
+        self.label = settings["label"]
         return self
 
     async def shutdown(self, exc_info: Optional[Tuple] = None):

--- a/examples/presenting_revoked_credential/docker-compose.yml
+++ b/examples/presenting_revoked_credential/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "3001:3001"
     command: >
       start
+        --label Alice
         --inbound-transport http 0.0.0.0 3000
         --outbound-transport http
         --endpoint http://alice:3000
@@ -52,6 +53,7 @@ services:
       - "3002:3001"
     command: >
       start
+        --label Bob
         --inbound-transport http 0.0.0.0 3000
         --outbound-transport http
         --endpoint http://bob:3000

--- a/examples/simple/docker-compose.yml
+++ b/examples/simple/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "3001:3001"
     command: >
       start
+        --label Alice
         --inbound-transport http 0.0.0.0 3000
         --outbound-transport http
         --endpoint http://alice:3000
@@ -38,6 +39,7 @@ services:
       - "3002:3001"
     command: >
       start
+        --label Bob
         --inbound-transport http 0.0.0.0 3000
         --outbound-transport http
         --endpoint http://bob:3000
@@ -72,6 +74,7 @@ services:
       - ALICE=http://alice:3001
       - BOB=http://bob:3001
     volumes:
+      - ../../controller:/usr/src/app/controller:z
       - ./example.py:/usr/src/app/example.py:ro,z
     command: python -m example
     depends_on:

--- a/examples/tunnels/docker-compose.yml
+++ b/examples/tunnels/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       /bin/sh -c '/tunnel_endpoint.sh aca-py "$$@"' --
     command: >
       start
+        --label Alice
         --inbound-transport http 0.0.0.0 3000
         --outbound-transport http
         --admin 0.0.0.0 3001
@@ -69,6 +70,7 @@ services:
       /bin/sh -c '/tunnel_endpoint.sh aca-py "$$@"' --
     command: >
       start
+        --label Bob
         --inbound-transport http 0.0.0.0 3000
         --outbound-transport http
         --admin 0.0.0.0 3001


### PR DESCRIPTION
This PR fixes a regression in displaying the Agent's label in the logs for webhooks received over websockets. This used to be set by extracting the label from the settings event (which is the first event sent down the websocket on connect). At some point, this was lost. This PR restores this.