### PR TITLE
feat: add timeout to controller.py

### DIFF
--- a/controller/controller.py
+++ b/controller/controller.py
@@ -556,20 +556,15 @@ class Controller:
         topic: str,
         *,
         record_type: Optional[Type[T]] = None,
-        timeout: float = 5.0,  # seconds
+        timeout: Optional[int] = None,  # seconds
         **values,
     ) -> Union[T, Mapping[str, Any]]:
         """Get a record from an event with values matching those passed in."""
         try:
-            event = await asyncio.wait_for(
-                self.event_queue.get(
-                    lambda event: event.topic == topic
-                    and all(
-                        [
-                            event.payload.get(key) == value
-                            for key, value in values.items()
-                        ]
-                    )
+            event = await self.event_queue.get(
+                lambda event: event.topic == topic
+                and all(
+                    [event.payload.get(key) == value for key, value in values.items()]
                 ),
                 timeout=timeout,
             )

--- a/controller/controller.py
+++ b/controller/controller.py
@@ -556,15 +556,22 @@ class Controller:
         topic: str,
         *,
         record_type: Optional[Type[T]] = None,
+        timeout: float = 5.0,  # seconds
         **values,
     ) -> Union[T, Mapping[str, Any]]:
         """Get a record from an event with values matching those passed in."""
         try:
-            event = await self.event_queue.get(
-                lambda event: event.topic == topic
-                and all(
-                    [event.payload.get(key) == value for key, value in values.items()]
-                )
+            event = await asyncio.wait_for(
+                self.event_queue.get(
+                    lambda event: event.topic == topic
+                    and all(
+                        [
+                            event.payload.get(key) == value
+                            for key, value in values.items()
+                        ]
+                    )
+                ),
+                timeout=timeout,
             )
         except asyncio.TimeoutError:
             raise ControllerError(


### PR DESCRIPTION
Requested from Daniel ~

Original Post:
Re: timeouts, we would need to adjust the timeouts on the `record_with_value calls` which is actually happening in the `protocols` methods we're calling, I think. We'd need to update the acapy-minimal-example `controller` to allow us to set a default timeout.