### PR TITLE
fix: event should be vanilla dataclass

### DIFF
--- a/acapy_controller/events.py
+++ b/acapy_controller/events.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Mapping, Optional
 
 from aiohttp import ClientSession, WSMsgType
 from async_selective_queue import AsyncSelectiveQueue as Queue
-from attr import dataclass
+from dataclasses import dataclass
 
 if TYPE_CHECKING:
     from .controller import Controller


### PR DESCRIPTION
This corrects an error that has been around for a while in the events module where the Event class is derived from the `@dataclass` decorator from `attr` instead of the built in python dataclass.