### PR TITLE
Add alias support to did-exchange

### DIFF
--- a/acapy_controller/protocols.py
+++ b/acapy_controller/protocols.py
@@ -191,6 +191,7 @@ async def didexchange(
     *,
     invite: Optional[InvitationMessage] = None,
     use_existing_connection: bool = False,
+    alias: Optional[str] = None,
 ):
     """Connect two agents using did exchange protocol."""
     if not invite:
@@ -201,6 +202,7 @@ async def didexchange(
         json=invite,
         params=params(
             use_existing_connection=use_existing_connection,
+            alias=alias,
         ),
         response=OobRecord,
     )


### PR DESCRIPTION
I'd like to be able to give an alias to a connection to support testing scenarios where an alias is used.